### PR TITLE
fix: call insertBefore with null only if nextSibling is an empty textnode

### DIFF
--- a/packages/nerv/__tests__/patch.spec.js
+++ b/packages/nerv/__tests__/patch.spec.js
@@ -180,8 +180,6 @@ describe('patch', () => {
         return (
           <div>
             <B visible={this.state.visible} />
-            <button onClick={this.setVisible.bind(this, true)}>yes</button>
-            <button onClick={this.setVisible.bind(this, false)}>no</button>
           </div>
         )
       }
@@ -191,16 +189,25 @@ describe('patch', () => {
     expect(cdm.callCount).toBe(1)
     inst.setVisible(true)
     inst.forceUpdate()
+    expect(scratch.innerHTML).toEqual(
+      normalizeHTML('<div><div><div>this is a plain div</div><div><div> this is a component</div></div></div></div>')
+    )
     expect(cwu.called).toBe(false)
     expect(cdm.callCount).toBe(1)
     expect(cdu.callCount).toBe(1)
     inst.setVisible(false)
     inst.forceUpdate()
+    expect(scratch.innerHTML).toEqual(
+     normalizeHTML('<div><div><div><div> this is a component</div></div></div></div>')
+    )
     expect(cwu.called).toBe(false)
     expect(cdm.callCount).toBe(1)
     expect(cdu.callCount).toBe(2)
     inst.setVisible(true)
     inst.forceUpdate()
+    expect(scratch.innerHTML).toEqual(
+      normalizeHTML('<div><div><div>this is a plain div</div><div><div> this is a component</div></div></div></div>')
+    )
     expect(cwu.called).toBe(false)
     expect(cdm.callCount).toBe(1)
     expect(cdu.callCount).toBe(3)

--- a/packages/nerv/src/vdom/patch.ts
+++ b/packages/nerv/src/vdom/patch.ts
@@ -74,7 +74,8 @@ export function patch (
       parentNode.insertBefore(
         newDom as Node,
         nextVnode !== null && (nextVnode.vtype & VType.Portal)
-        || isVText(nextVnode) && nextVnode.text === ''
+        || nextSibling === null
+        || nextSibling.nodeType === 3 && nextSibling.nodeValue === ''
           ? null
           : nextSibling
       )


### PR DESCRIPTION
218563a285dd81b853ac62c86fe850ae9355f12a fixed #40's unnecessary mount/unmount but introduce a new issue, see [demo](https://codesandbox.io/s/0pr0m5lmlv)

Notice how the two `div`s got position replaced. This is because this [condition](https://github.com/NervJS/nerv/blob/master/packages/nerv/src/vdom/patch.ts#L77) is not correct, so when div re-mounts, it got appended to the end of its parent.

This PR fixes this issue by checking if sibling is an empty textnode, and add more detailed testcase.