### PR TITLE
解决react-lifecycles-compat无法识别组件的问题

### DIFF
--- a/packages/nerv/src/component.ts
+++ b/packages/nerv/src/component.ts
@@ -22,7 +22,9 @@ class Component<P, S> implements ComponentLifecycle<P, S> {
   // Is a React Component.
   // tslint:disable-next-line:max-line-length
   // see: https://github.com/facebook/react/blob/3c977dea6b96f6a9bb39f09886848da870748441/packages/react/src/ReactBaseClasses.js#L26
-  isReactComponent = EMPTY_OBJ
+  isReactComponent(){
+    return true;
+  }
 
   constructor (props?: P, context?: any) {
     if (!this.state) {


### PR DESCRIPTION
https://github.com/reactjs/react-lifecycles-compat/blob/master/index.js#L53
在目前的版本，编译之后`isReactComponent`并不能在`Component.prototype`中找到，到时使用到react-lifecycles-compat的组件都无法在nerv正常运行。