### PR TITLE
Fix wrong context value after changing the context value

### DIFF
--- a/packages/nerv/__tests__/createContext.spec.js
+++ b/packages/nerv/__tests__/createContext.spec.js
@@ -460,6 +460,46 @@ describe('create-context', () => {
     expect(actual).toEqual('bob')
   })
 
+  it('should pass the correct value after changing the context value', () => {
+    const ctx = createContext('foo')
+    let doSetState = null
+
+    let actual
+    class Children extends Component {
+      render () {
+        actual = this.context
+        return <div>bar</div>
+      }
+    }
+
+    Children.contextType = ctx
+    const Provider = ctx.Provider
+
+    class App extends Component {
+      constructor () {
+        super(...arguments)
+        this.state = { value: 'bar' }
+      }
+      componentDidMount () {
+        doSetState = (value) => {
+          this.setState({ value })
+        }
+      }
+      render () {
+        return <Provider value={this.state.value}>
+          <Children />
+        </Provider>
+      }
+    }
+
+    render(<App />, scratch)
+    expect(actual).toEqual('bar')
+
+    doSetState('bob')
+    rerender()
+    expect(actual).toEqual('bob')
+  })
+
   it('should restore legacy context for children', () => {
     const Foo = createContext('foo')
     const spy = sinon.spy()

--- a/packages/nerv/src/full-component.ts
+++ b/packages/nerv/src/full-component.ts
@@ -2,7 +2,8 @@ import { VType, CompositeComponent, Ref } from 'nerv-shared'
 import {
   mountComponent,
   reRenderComponent,
-  unmountComponent
+  unmountComponent,
+  getContextByContextType
 } from './lifecycle'
 import Component from './component'
 import { isUndefined, isArray } from 'nerv-utils'
@@ -54,7 +55,7 @@ class ComponentWrapper implements CompositeComponent {
   }
 
   update (previous, current, parentContext, domNode?) {
-    this.context = parentContext
+    this.context = getContextByContextType(this, parentContext)
     options.beforeUpdate(this)
     const dom = reRenderComponent(previous, this)
     options.afterUpdate(this)


### PR DESCRIPTION
I wrote this test case:

```javascript

it('should pass the correct value after changing the context value', () => {
  const ctx = createContext('foo')
  let doSetState = null

  let actual
  class Children extends Component {
    render () {
      actual = this.context
      return <div>bar</div>
    }
  }

  Children.contextType = ctx
  const Provider = ctx.Provider

  class App extends Component {
    constructor () {
      super(...arguments)
      this.state = { value: 'bar' }
    }
    componentDidMount () {
      doSetState = (value) => {
        this.setState({ value })
      }
    }
    render () {
      return <Provider value={this.state.value}>
        <Children />
      </Provider>
    }
  }

  render(<App />, scratch)
  expect(actual).toEqual('bar')

  doSetState('bob')
  rerender()
  expect(actual).toEqual('bob')
})

```

Test result:

```
    Expected value to equal:
      "bob"
    Received:
      {"__context_11__": {"handlers": [], "value": "bob"}}
```