### PR TITLE
useDebugValue dummy function for compatibility with react-jss 10.0.0

### DIFF
--- a/packages/nerv/src/hooks.ts
+++ b/packages/nerv/src/hooks.ts
@@ -231,3 +231,5 @@ export function useImperativeHandle<T, R extends T> (
     }
   }, isArray(deps) ? deps.concat([ref]) : undefined)
 }
+
+export function useDebugValue (v: any): void { return }

--- a/packages/nerv/src/index.ts
+++ b/packages/nerv/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from './dom'
 import { PropTypes } from './prop-types' // for React 15- compat
 // tslint:disable-next-line: max-line-length
-import { getHooks, useEffect, useLayoutEffect, useReducer, useState, useRef, useCallback, useMemo, useImperativeHandle, useContext } from './hooks'
+import { getHooks, useEffect, useLayoutEffect, useReducer, useState, useRef, useCallback, useMemo, useImperativeHandle, useContext, useDebugValue } from './hooks'
 import { createRef, forwardRef } from './create-ref'
 import { memo } from './memo'
 import { createContext } from './create-context'
@@ -54,7 +54,8 @@ export {
   getHooks,
   Current,
   Fragment,
-  useEffect, useLayoutEffect, useReducer, useState, useRef, useCallback, useMemo, useImperativeHandle, useContext
+  useEffect, useLayoutEffect, useReducer, useState, useRef, useCallback, useMemo, useImperativeHandle, useContext,
+  useDebugValue
 }
 
 export default {
@@ -84,5 +85,6 @@ export default {
   getHooks,
   Current,
   useEffect, useLayoutEffect, useReducer, useState, useRef, useCallback, useMemo, useImperativeHandle, useContext,
+  useDebugValue,
   Fragment
 }


### PR DESCRIPTION
Hi,

this implements a dummy useDebugValue for compatibility with react-jss 10.0.0.

```
Test Suites: 28 passed, 28 total
Tests:       9 skipped, 373 passed, 382 total
Snapshots:   1 passed, 1 total
Time:        2.552s, estimated 6s
Ran all test suites.
```