### PR TITLE
fix(nerv-server): extend the method of renderVodeToString to support void and array vnode

### DIFF
--- a/packages/nerv-server/__tests__/render.spec.js
+++ b/packages/nerv-server/__tests__/render.spec.js
@@ -1,5 +1,5 @@
 /** @jsx createElement */
-import { Component, createElement } from 'nervjs'
+import { Component, createElement, Fragment } from 'nervjs'
 import sinon from 'sinon'
 import { renderToString } from '../src'
 const render = renderToString
@@ -91,6 +91,16 @@ describe('render', () => {
       expect(rendered).toEqual(
         `<svg><image xlink:href="#"></image><foreignObject><div xlinkHref="#"></div></foreignObject><g><image xlink:href="#"></image></g></svg>`
       )
+    })
+
+    it('should render Fragment child elements', () => {
+      const rendered = render(
+        <Fragment>
+          {[1].map(() => <div>Fragment</div>)}
+        </Fragment>
+      )
+      const expected = `<div>Fragment</div>`
+      expect(rendered).toEqual(expected)
     })
   })
 

--- a/packages/nerv-server/src/index.ts
+++ b/packages/nerv-server/src/index.ts
@@ -157,7 +157,14 @@ function renderVNodeToString (vnode, parent, context, isSvg?: boolean) {
       context = extend(clone(context), instance.getChildContext())
     }
     return renderVNodeToString(rendered, vnode, context, isSvg)
+  } else if (Array.isArray(vnode)) {
+    let result = ''
+    vnode.forEach((vnodeItem) => {
+      result += renderVNodeToString(vnodeItem, {}, {})
+    })
+    return result
   }
+  return ''
 }
 
 export function renderToString (input: any): string {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
使用Taro时，当用<Block>包裹多个条件表达式时，这时Block包裹的子元素的vnode为Array类型且没有vType，截图如下：

![image](https://user-images.githubusercontent.com/20263880/78466386-18b87280-7733-11ea-9086-3193e95a59d1.png)
![image](https://user-images.githubusercontent.com/20263880/78466194-f6bdf080-7730-11ea-8926-a5c934ff05ba.png)

打了断点，相应的输出截图如下所示：
![image](https://user-images.githubusercontent.com/20263880/78466386-18b87280-7733-11ea-9086-3193e95a59d1.png)

为了解决上述问题，在nerv-server库中的`renderVnodeToString`方法中增加了对Array类型vnode的支持，此外对为覆盖到的void类型的`vnode`也进行了处理，避免`snapshot`中出现`undefined`字眼引起困惑。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能