### PR TITLE
fix: shallowEqual(null, null) shold be true

### DIFF
--- a/packages/nerv-utils/__tests__/shallow-equal.spec.js
+++ b/packages/nerv-utils/__tests__/shallow-equal.spec.js
@@ -11,6 +11,7 @@ describe('shallowEqual', () => {
     const g = { a: 1, v: arr1 }
     expect(shallowEqual(a, b)).not.toBeTruthy()
     expect(shallowEqual(null, 110)).toBeFalsy()
+    expect(shallowEqual(null, null)).toBeTruthy()
     expect(shallowEqual(+0, -0)).toBeTruthy()
     expect(shallowEqual([], [1])).toBeFalsy()
     expect(shallowEqual(a, c)).toBeTruthy()

--- a/packages/nerv-utils/src/shallow-equal.ts
+++ b/packages/nerv-utils/src/shallow-equal.ts
@@ -8,11 +8,11 @@ Object.is = Object.is || function (x, y) {
 }
 
 export default function shallowEqual (obj1, obj2) {
-  if (obj1 === null || obj2 === null) {
-    return false
-  }
   if (Object.is(obj1, obj2)) {
     return true
+  }
+  if (obj1 === null || obj2 === null) {
+    return false
   }
   const obj1Keys = obj1 ? Object.keys(obj1) : []
   const obj2Keys = obj2 ? Object.keys(obj2) : []


### PR DESCRIPTION
因为 严格相等(===) 和 同值相等(Object.is) 都为 true ，所以 shallowEqual(null, null) 也应该为 true