### PR TITLE
Set correct location of typescript definition file

### DIFF
--- a/packages/nerv/package.json
+++ b/packages/nerv/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "module": "dist/index.esm.js",
   "jsnext:main": "dist/index.esm.js",
-  "typings": "index.d.ts",
+  "typings": "dist/index.d.ts",
   "unpkg": "dist/nerv.js",
   "jsdelivr": "dist/nerv.js",
   "files": [


### PR DESCRIPTION
Fixing:

```
Could not find a declaration file for module 'nervjs'. 
'./default/node_modules/nervjs/index.js' implicitly has an 'any' type. 
Try `npm install @types/nervjs` if it exists 
or add a new declaration (.d.ts) file containing `declare module 'nervjs';
```